### PR TITLE
generate keys w/ ursa, fallback to node-forge

### DIFF
--- a/lib/crypto-util.js
+++ b/lib/crypto-util.js
@@ -96,7 +96,22 @@ module.exports = {
   ///// KEY PAIR MANAGEMENT
 
   generateKeyPair: function(bits) {
-    var keyPair = forge.pki.rsa.generateKeyPair({bits: bits, e: 0x10001});
+    var ursa, keyPair;
+
+    try {
+      ursa = require('ursa');
+    } catch(e) {
+      // ignore
+    }
+
+    if (ursa) {
+      // This takes between 2 and 6 seconds on a raspberry pi
+      keyPair = ursa.generatePrivateKey(bits, 0x10001);
+      return module.exports.importPemPrivateKey(keyPair.toPrivatePem('utf8'));
+    }
+
+    // This takes 20-30 minutes on a raspberry pi
+    keyPair = forge.pki.rsa.generateKeyPair({bits: bits, e: 0x10001});
     return {
       privateKey: exportPrivateKey(keyPair.privateKey),
       publicKey: exportPublicKey(keyPair.publicKey)


### PR DESCRIPTION
Running the demo went from 89 minutes down to about 3 on raspberry pi.

Related:

* https://github.com/digitalbazaar/forge/issues/263
* https://github.com/letsencrypt/node-acme/issues/22.